### PR TITLE
default to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and downloading the `.whl` file from there.
 
 Install it using `pip`:
 
-    pip install ecpp-*.whl
+    pip3 install ecpp-*.whl
 
 Verify that it can be executed:
 
@@ -43,7 +43,7 @@ Verify that it can be executed:
 
 Install `gmpy2` package to double the performance of certificate verification:
 
-    pip install gmpy2
+    pip3 install gmpy2
 
 ## From sources
 
@@ -58,7 +58,7 @@ Install dependencies (for example on Fedora):
 
 Or from PyPI:
 
-    pip install ecdsa[gmpy2]
+    pip3 install ecdsa[gmpy2]
 
 (Note: as `gmpy2` is a binary package you will need to install development
 headers for python and the gmp library. Alternatively, you can skip

--- a/README.md
+++ b/README.md
@@ -74,15 +74,29 @@ Run `ecpp` for the first time:
 
 # Usage
 
-## Verifying primes in OpenSSH moduli file
+## Matching certificates to primes in OpenSSH moduli file
 
-To verify you have primality certificates for all the primes in your OpenSSH
+To check if you have primality certificates for all the primes in your OpenSSH
 moduli file, you can use ecpp with `-m` switch:
 
     ecpp -m /etc/ssh/moduli
 
 This will succeed for example for moduli file released with OpenSSH 8.2p1,
 listing certificates for each prime.
+
+## Verifying primality certificates for primes in moduli file
+
+To verify the matching certificates you can combine the `-m` switch with
+the `-v` switch:
+
+    ecpp -m /etc/ssh/moduli -v
+
+This will succeed if the script finds matching certificates and verifies
+them as valid.
+
+Note: it will require significantly more time to execute than just the `-m`
+option. It's also a single-threaded process, see
+[#12](https://github.com/tomato42/ecpp-verifier/issues/12).
 
 ## Generating primality certificates for primes in moduli file for OpenSSH
 
@@ -120,7 +134,7 @@ in this example using 16 parallel processes:
 Now, we can add the primality certificates to `src/ecpp/certificates/`
 directory.
 
-## Verifying primes in OpenSSH moduli file again
+## Matching certificates to primes in OpenSSH moduli file again
 
 Running `ecpp` again as in the first example should confirm we have
 a certificate for each prime in the moduli file now.

--- a/ecpp
+++ b/ecpp
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Author: Hubert Kario, Stefan Dordevic
 # Released under Gnu GPL v2.1, see LICENSE file for details

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import io
 import os


### PR DESCRIPTION
As Python2 is not officially supported by upstream any more, and
many modern distros don't even ship python2 any more, do default
to using python3.

(Python2 is still supported, it just requires using python2 executable
explicitly for running ecpp or setup.py)

fixes #46